### PR TITLE
Fix the instruction in Download page

### DIFF
--- a/download/index.html
+++ b/download/index.html
@@ -105,7 +105,8 @@ BL: removed since they make things SLOW
 
 <p>To install natively on Ubuntu from source, the basic technique is:</p>
 
-<pre><code>git clone git://github.com/mininet/mininet
+<pre><code>cd ~
+git clone git://github.com/mininet/mininet
 mininet/util/install.sh -a
 </code></pre>
 


### PR DESCRIPTION
In the "Option 3 (on Ubuntu 12.04 and later): Native Installation from Packages", the tutorial should add a line to cd into ~ directory right before cloning the mininet repo.
