### PR TITLE
Fix typo + broken links

### DIFF
--- a/contribute/index.html
+++ b/contribute/index.html
@@ -1,4 +1,3 @@
-
 <!DOCTYPE html>
 <!--[if IEMobile 7 ]><html class="no-js iem7"><![endif]-->
 <!--[if lt IE 9]><html class="no-js lte-ie8"><![endif]-->
@@ -88,12 +87,12 @@ BL: removed since they make things SLOW
 
 <h3 id="enhance-the-mininet-documentation">Enhance the Mininet Documentation</h3>
 
-<p>High-quality documentation drastically enhances the usability of any project. Much of Mininet’s documentation is directly editable on the wiki at <a href="docs">docs.mininet.org</a> .</p>
+<p>High-quality documentation drastically enhances the usability of any project. Much of Mininet’s documentation is directly editable on the wiki at <a href="http://docs.mininet.org">docs.mininet.org</a> .</p>
 
 <h3 id="create-mininet-apps">Create Mininet Apps</h3>
 
-<p>Mininet is a useful platform for a variety of applications. Creaete your own and add them to 
-<a href="apps">apps.mininet.org</a></p>
+<p>Mininet is a useful platform for a variety of applications. Create your own and add them to 
+<a href="http://apps.mininet.org">apps.mininet.org</a></p>
 
 <h3 id="create-useful-tools-extensions-topologies-classes-and-other-packages">Create Useful Tools, Extensions, Topologies, Classes, and other Packages</h3>
 
@@ -101,7 +100,7 @@ BL: removed since they make things SLOW
 
 <h3 id="participate-in-google-summer-of-code">Participate in Google Summer of Code</h3>
 
-<p>Several Google Summer of Code 2013 participants have selected Mininet-based projects. Additional information can be found at <a href="gsoc">gsoc.mininet.org</a> .</p>
+<p>Several Google Summer of Code 2013 participants have selected Mininet-based projects. Additional information can be found at <a href="http://gsoc.mininet.org">gsoc.mininet.org</a> .</p>
 
   
     <footer>


### PR DESCRIPTION
Under section "Create Mininet Apps":
'Creaete' changed to 'Create'

Fixed broken links:
apps
docs
gsoc
