### PR TITLE
Remove unencrypted git protocol use from the documentations

### DIFF
--- a/download/index.html
+++ b/download/index.html
@@ -137,7 +137,7 @@ complete the <a href="https://github.com/mininet/openflow-tutorial/wiki">OpenFlo
 
 <p>To install natively from source, first you need to get the source code:</p>
 
-<pre><code>git clone git://github.com/mininet/mininet
+<pre><code>git clone https://github.com/mininet/mininet
 </code></pre>
 
 <p>Note that the above <code>git</code> command will check out the latest and greatest Mininet
@@ -244,7 +244,7 @@ sudo service openvswitch-switch start
 
 <p>If you wish to go through the Mininet walkthrough, you will want to install additional software. The following commands</p>
 
-<pre><code>git clone git://github.com/mininet/mininet
+<pre><code>git clone https://github.com/mininet/mininet
 mininet/util/install.sh -fw
 </code></pre>
 
@@ -348,7 +348,7 @@ page, though we don't really recommend using it.
 
 You can also use the archived `install-precise` branch to install Mininet 1.0 on Ubuntu 12.04:
 
-    git clone git://github.com/mininet/mininet
+    git clone https://github.com/mininet/mininet
     cd mininet
     git fetch
     git checkout -b install-precise origin/devel/install-precise


### PR DESCRIPTION
GitHub recently updated Git protocol security, and the usage of the unencrypted git protocol will be retired permanently on March 15th. The same has been updated for the Mininet INSTALL script but not on the website. 

When trying to install Mininet from source as mentioned on the website it shows error.

Hence, update the Mininet website to reflect the same on the website.

Reference : https://github.blog/2021-09-01-improving-git-protocol-security-github/